### PR TITLE
Move errorprone to global dependency

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -88,9 +88,9 @@
       <artifactId>jdk8</artifactId>
       <version>2.7.0</version>
     </dependency>
-    <!-- We add errorprone here instead of using annotationProcessorPaths as its documentation suggests -->
-    <!-- because if that option is used, classpath won't be searched for annotation processors, -->
-    <!-- and then the processors in the local checker-framework can't be loaded -->
+    <!-- Add errorprone here instead of using annotationProcessorPaths (as its documentation suggests) -->
+    <!-- because if that option is used, the classpath won't be searched for annotation processors, -->
+    <!-- and then the processors in the local Checker Framework installation can't be loaded. -->
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>jdk8</artifactId>
       <version>2.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_core</artifactId>
+      <version>2.3.3</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -143,13 +148,6 @@
               <Xmaxerrs>10000</Xmaxerrs>
               <Xmaxwarns>10000</Xmaxwarns>
             </compilerArguments>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.3.3</version>
-              </path>
-            </annotationProcessorPaths>
             <annotationProcessors>
               <annotationProcessor>${checkerframework.checkers}</annotationProcessor>
             </annotationProcessors>
@@ -176,13 +174,6 @@
             <goals><goal>compile</goal></goals>
             <configuration>
               <fork>true</fork>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>2.3.3</version>
-                </path>
-              </annotationProcessorPaths>
               <annotationProcessors>
                 <annotationProcessor>org.checkerframework.checker.index.IndexChecker</annotationProcessor>
               </annotationProcessors>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -88,6 +88,9 @@
       <artifactId>jdk8</artifactId>
       <version>2.7.0</version>
     </dependency>
+    <!-- We add errorprone here instead of using annotationProcessorPaths as its documentation suggests -->
+    <!-- because if that option is used, classpath won't be searched for annotation processors, -->
+    <!-- and then the processors in the local checker-framework can't be loaded -->
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>


### PR DESCRIPTION
It turns out that the option `annotationProcessorPaths` was not introduced to the compiler plugin until version 3.5, and guava used 3.3. However, we still can't use this option even if a higher version is used, because if this option is provided, annotation processors will only be searched in these paths, and if this option is not provided, [classpath will be searched by default](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths), which is necessary if the local checker-framework is to be used.

So the solution is to move errorprone to the global dependency list and not provide `annotationProcessorPaths`.