### PR TITLE
Ci fix

### DIFF
--- a/android/guava-bom/pom.xml
+++ b/android/guava-bom/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.google.guava</groupId>
   <artifactId>guava-bom</artifactId>
-  <version>33.1.0-android</version>
+  <version>33.1.0.2-android</version>
   <packaging>pom</packaging>
   
   <parent>

--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -19,9 +19,8 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
+      <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -21,6 +21,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-android</version>
+    <version>33.1.0.2-android</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>

--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -69,6 +69,13 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.self="override">
+            <arg>-sourcepath</arg>
+            <arg>doesnotexist</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -69,13 +69,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs combine.self="override">
-            <arg>-sourcepath</arg>
-            <arg>doesnotexist</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-android</version>
+    <version>33.1.0.2-android</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -26,7 +26,7 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
+      <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checker.version}</version>
     </dependency>

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-android</version>
+    <version>33.1.0.2-android</version>
   </parent>
   <artifactId>guava</artifactId>
   <packaging>bundle</packaging>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -18,6 +18,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
+    <errorprone.compiler.arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</errorprone.compiler.arg>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -463,7 +464,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+                <arg>${errorprone.compiler.arg}</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.49.3-eisop1</checker.version>
+    <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -141,18 +141,15 @@
               <arg>-XDcompilePolicy=simple</arg>
               <!-- -Xplugin:ErrorProne is set conditionally by a profile. -->
             </compilerArgs>
+	    <!--
             <annotationProcessorPaths>
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
-              </path>
-              <path>
-                <groupId>io.github.eisop</groupId>
-                <artifactId>checker</artifactId>
-                <version>${checker.version}</version>
+                <version>2.23.0</version>
               </path>
             </annotationProcessorPaths>
+	    -->
             <!-- Fork:
 
                  - for JDK8 because we use a javac9 bootclasspath
@@ -463,7 +460,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -141,15 +141,18 @@
               <arg>-XDcompilePolicy=simple</arg>
               <!-- -Xplugin:ErrorProne is set conditionally by a profile. -->
             </compilerArgs>
-	    <!--
             <annotationProcessorPaths>
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.23.0</version>
+                <version>${errorprone.version}</version>
+              </path>
+              <path>
+                <groupId>io.github.eisop</groupId>
+                <artifactId>checker</artifactId>
+                <version>${checker.version}</version>
               </path>
             </annotationProcessorPaths>
-	    -->
             <!-- Fork:
 
                  - for JDK8 because we use a javac9 bootclasspath
@@ -460,7 +463,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -18,7 +18,6 @@
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
-    <errorprone.compiler.arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</errorprone.compiler.arg>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -464,7 +463,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>${errorprone.compiler.arg}</arg>
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -460,7 +460,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.49.1-eisop1</checker.version>
+    <checker.version>3.49.3-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent</artifactId>
-  <version>33.1.0-android</version>
+  <version>33.1.0.2-android</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
   <description>Parent for guava artifacts</description>
@@ -29,7 +29,7 @@
     <module.status>release</module.status>
     <variant.jvmEnvironment>android</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>android</variant.jvmEnvironmentVariantName>
-    <otherVariant.version>33.1.0-jre</otherVariant.version>
+    <otherVariant.version>33.1.0.2-jre</otherVariant.version>
     <otherVariant.jvmEnvironment>standard-jvm</otherVariant.jvmEnvironment>
     <otherVariant.jvmEnvironmentVariantName>jre</otherVariant.jvmEnvironmentVariantName>
   </properties>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.34.0-eisop1</checker.version>
+    <checker.version>3.49.1-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -460,7 +460,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/guava-bom/pom.xml
+++ b/guava-bom/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.google.guava</groupId>
   <artifactId>guava-bom</artifactId>
-  <version>33.1.0-jre</version>
+  <version>33.1.0.2-jre</version>
   <packaging>pom</packaging>
   
   <parent>

--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-jre</version>
+    <version>33.1.0.2-jre</version>
   </parent>
   <artifactId>guava-gwt</artifactId>
   <name>Guava GWT compatible libs</name>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-jre</version>
+    <version>33.1.0.2-jre</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -21,6 +21,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -75,13 +75,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs combine.self="override">
-            <arg>-sourcepath</arg>
-            <arg>doesnotexist</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>33.1.0-jre</version>
+    <version>33.1.0.2-jre</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -75,6 +75,13 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.self="override">
+            <arg>-sourcepath</arg>
+            <arg>doesnotexist</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava/cfMavenCentral.xml
+++ b/guava/cfMavenCentral.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>3.42.0-eisop5</version>
+      <version>3.49.1-eisop1</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava/cfMavenCentral.xml
+++ b/guava/cfMavenCentral.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>3.49.3-eisop1</version>
+      <version>3.49.5-eisop1</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava/cfMavenCentral.xml
+++ b/guava/cfMavenCentral.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>3.49.1-eisop1</version>
+      <version>3.49.3-eisop1</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava/module.json
+++ b/guava/module.json
@@ -48,7 +48,7 @@
           }
         },
         {
-          "group": "org.checkerframework",
+          "group": "io.github.eisop",
           "module": "checker-qual",
           "version": {
             "requires": "${checker.version}"
@@ -121,7 +121,7 @@
           }
         },
         {
-          "group": "org.checkerframework",
+          "group": "io.github.eisop",
           "module": "checker-qual",
           "version": {
             "requires": "${checker.version}"
@@ -187,7 +187,7 @@
           }
         },
         {
-          "group": "org.checkerframework",
+          "group": "io.github.eisop",
           "module": "checker-qual",
           "version": {
             "requires": "${checker.version}"
@@ -260,7 +260,7 @@
           }
         },
         {
-          "group": "org.checkerframework",
+          "group": "io.github.eisop",
           "module": "checker-qual",
           "version": {
             "requires": "${checker.version}"

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -64,17 +64,17 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-util</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker</artifactId>
-      <version>0.0.0</version>
+      <version>${checker.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -64,14 +64,17 @@
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-qual</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker-util</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.eisop</groupId>
       <artifactId>checker</artifactId>
+      <version>0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -1,11 +1,6 @@
 val runningGradle5 = gradle.gradleVersion.startsWith("5.")
 
 val pomText = file("../../pom.xml").readText()
-val androidPomFile =
-  listOf(file("../../android/pom.xml"), file("../../android-pom.xml"))
-    .firstOrNull { it.isFile }
-    ?: error("android pom not found")
-val androidPomText = androidPomFile.readText()
 val guavaVersionJre =
   "<version>(.*)</version>".toRegex().find(pomText)?.groups?.get(1)?.value
     ?: error("version not found in pom")
@@ -15,9 +10,6 @@ val checkerVersion =
 val errorProneVersionJre =
   "<errorprone.version>(.*)</errorprone.version>".toRegex().find(pomText)?.groups?.get(1)?.value
     ?: error("errorprone.version not found in pom")
-val errorProneVersionAndroid =
-  "<errorprone.version>(.*)</errorprone.version>".toRegex().find(androidPomText)?.groups?.get(1)?.value
-    ?: error("errorprone.version not found in android pom")
 
 val expectedReducedRuntimeClasspathAndroidVersion =
   setOf(
@@ -25,7 +17,7 @@ val expectedReducedRuntimeClasspathAndroidVersion =
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
     "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-$errorProneVersionAndroid.jar",
+    "error_prone_annotations-$errorProneVersionJre.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
 val expectedReducedRuntimeClasspathJreVersion =
@@ -37,32 +29,10 @@ val expectedReducedRuntimeClasspathJreVersion =
     "error_prone_annotations-$errorProneVersionJre.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
-val expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata =
-  setOf(
-    "guava-${guavaVersionJre.replace("jre", "android")}.jar",
-    "failureaccess-1.0.2.jar",
-    "jsr305-3.0.2.jar",
-    "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-$errorProneVersionJre.jar",
-    "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
-  )
-val expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata =
-  setOf(
-    "guava-$guavaVersionJre.jar",
-    "failureaccess-1.0.2.jar",
-    "jsr305-3.0.2.jar",
-    "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-$errorProneVersionAndroid.jar",
-    "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
-  )
 val expectedCompileClasspathAndroidVersion =
   expectedReducedRuntimeClasspathAndroidVersion + setOf("j2objc-annotations-3.0.0.jar")
 val expectedCompileClasspathJreVersion =
   expectedReducedRuntimeClasspathJreVersion + setOf("j2objc-annotations-3.0.0.jar")
-val expectedCompileClasspathAndroidVersionFromJreMetadata =
-  expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata + setOf("j2objc-annotations-3.0.0.jar")
-val expectedCompileClasspathJreVersionFromAndroidMetadata =
-  expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata + setOf("j2objc-annotations-3.0.0.jar")
 val expectedPomClasspathJreVersion =
   expectedCompileClasspathJreVersion +
     setOf(
@@ -115,18 +85,10 @@ subprojects {
       if (name.contains("Android") && !name.contains("JreConstraint")) {
         when {
           name.contains("RuntimeClasspath") -> {
-            if (name.startsWith("android")) {
-              expectedReducedRuntimeClasspathAndroidVersion
-            } else {
-              expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata
-            }
+            expectedReducedRuntimeClasspathAndroidVersion
           }
           name.contains("CompileClasspath") -> {
-            if (name.startsWith("android")) {
-              expectedCompileClasspathAndroidVersion
-            } else {
-              expectedCompileClasspathAndroidVersionFromJreMetadata
-            }
+            expectedCompileClasspathAndroidVersion
           }
           else -> {
             error("unexpected classpath type: $name")
@@ -135,18 +97,10 @@ subprojects {
       } else {
         when {
           name.contains("RuntimeClasspath") -> {
-            if (name.startsWith("android")) {
-              expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata
-            } else {
-              expectedReducedRuntimeClasspathJreVersion
-            }
+            expectedReducedRuntimeClasspathJreVersion
           }
           name.contains("CompileClasspath") -> {
-            if (name.startsWith("android")) {
-              expectedCompileClasspathJreVersionFromAndroidMetadata
-            } else {
-              expectedCompileClasspathJreVersion
-            }
+            expectedCompileClasspathJreVersion
           }
           else -> {
             error("unexpected classpath type: $name")

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -33,10 +33,32 @@ val expectedReducedRuntimeClasspathJreVersion =
     "error_prone_annotations-$errorProneVersionJre.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
+val expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata =
+  setOf(
+    "guava-${guavaVersionJre.replace("jre", "android")}.jar",
+    "failureaccess-1.0.2.jar",
+    "jsr305-3.0.2.jar",
+    "checker-qual-$checkerVersion.jar",
+    "error_prone_annotations-$errorProneVersionJre.jar",
+    "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  )
+val expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata =
+  setOf(
+    "guava-$guavaVersionJre.jar",
+    "failureaccess-1.0.2.jar",
+    "jsr305-3.0.2.jar",
+    "checker-qual-$checkerVersion.jar",
+    "error_prone_annotations-$errorProneVersionAndroid.jar",
+    "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+  )
 val expectedCompileClasspathAndroidVersion =
   expectedReducedRuntimeClasspathAndroidVersion + setOf("j2objc-annotations-3.0.0.jar")
 val expectedCompileClasspathJreVersion =
   expectedReducedRuntimeClasspathJreVersion + setOf("j2objc-annotations-3.0.0.jar")
+val expectedCompileClasspathAndroidVersionFromJreMetadata =
+  expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata + setOf("j2objc-annotations-3.0.0.jar")
+val expectedCompileClasspathJreVersionFromAndroidMetadata =
+  expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata + setOf("j2objc-annotations-3.0.0.jar")
 val expectedPomClasspathJreVersion =
   expectedCompileClasspathJreVersion +
     setOf(
@@ -89,10 +111,18 @@ subprojects {
       if (name.contains("Android") && !name.contains("JreConstraint")) {
         when {
           name.contains("RuntimeClasspath") -> {
-            expectedReducedRuntimeClasspathAndroidVersion
+            if (name.startsWith("android")) {
+              expectedReducedRuntimeClasspathAndroidVersion
+            } else {
+              expectedReducedRuntimeClasspathAndroidVersionFromJreMetadata
+            }
           }
           name.contains("CompileClasspath") -> {
-            expectedCompileClasspathAndroidVersion
+            if (name.startsWith("android")) {
+              expectedCompileClasspathAndroidVersion
+            } else {
+              expectedCompileClasspathAndroidVersionFromJreMetadata
+            }
           }
           else -> {
             error("unexpected classpath type: $name")
@@ -101,10 +131,18 @@ subprojects {
       } else {
         when {
           name.contains("RuntimeClasspath") -> {
-            expectedReducedRuntimeClasspathJreVersion
+            if (name.startsWith("android")) {
+              expectedReducedRuntimeClasspathJreVersionFromAndroidMetadata
+            } else {
+              expectedReducedRuntimeClasspathJreVersion
+            }
           }
           name.contains("CompileClasspath") -> {
-            expectedCompileClasspathJreVersion
+            if (name.startsWith("android")) {
+              expectedCompileClasspathJreVersionFromAndroidMetadata
+            } else {
+              expectedCompileClasspathJreVersion
+            }
           }
           else -> {
             error("unexpected classpath type: $name")

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -3,13 +3,16 @@ val runningGradle5 = gradle.gradleVersion.startsWith("5.")
 val guavaVersionJre =
   "<version>(.*)</version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
     ?: error("version not found in pom")
+val checkerVersion =
+  "<checker.version>(.*)</checker.version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
+    ?: error("checker.version not found in pom")
 
 val expectedReducedRuntimeClasspathAndroidVersion =
   setOf(
     "guava-${guavaVersionJre.replace("jre", "android")}.jar",
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
-    "checker-qual-3.46.0.jar",
+    "checker-qual-$checkerVersion.jar",
     "error_prone_annotations-2.26.1.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
@@ -18,7 +21,7 @@ val expectedReducedRuntimeClasspathJreVersion =
     "guava-$guavaVersionJre.jar",
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
-    "checker-qual-3.46.0.jar",
+    "checker-qual-$checkerVersion.jar",
     "error_prone_annotations-2.26.1.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -1,23 +1,18 @@
 val runningGradle5 = gradle.gradleVersion.startsWith("5.")
 
-val pomText = file("../../pom.xml").readText()
 val guavaVersionJre =
-  "<version>(.*)</version>".toRegex().find(pomText)?.groups?.get(1)?.value
+  "<version>(.*)</version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
     ?: error("version not found in pom")
 val checkerVersion =
-  "<checker.version>(.*)</checker.version>".toRegex().find(pomText)?.groups?.get(1)?.value
+  "<checker.version>(.*)</checker.version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
     ?: error("checker.version not found in pom")
-val errorProneVersionJre =
-  "<errorprone.version>(.*)</errorprone.version>".toRegex().find(pomText)?.groups?.get(1)?.value
-    ?: error("errorprone.version not found in pom")
-
 val expectedReducedRuntimeClasspathAndroidVersion =
   setOf(
     "guava-${guavaVersionJre.replace("jre", "android")}.jar",
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
     "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-$errorProneVersionJre.jar",
+    "error_prone_annotations-2.26.1.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
 val expectedReducedRuntimeClasspathJreVersion =
@@ -26,7 +21,7 @@ val expectedReducedRuntimeClasspathJreVersion =
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
     "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-$errorProneVersionJre.jar",
+    "error_prone_annotations-2.26.1.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
 val expectedCompileClasspathAndroidVersion =

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -1,7 +1,11 @@
 val runningGradle5 = gradle.gradleVersion.startsWith("5.")
 
 val pomText = file("../../pom.xml").readText()
-val androidPomText = file("../../android-pom.xml").readText()
+val androidPomFile =
+  listOf(file("../../android/pom.xml"), file("../../android-pom.xml"))
+    .firstOrNull { it.isFile }
+    ?: error("android pom not found")
+val androidPomText = androidPomFile.readText()
 val guavaVersionJre =
   "<version>(.*)</version>".toRegex().find(pomText)?.groups?.get(1)?.value
     ?: error("version not found in pom")

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -1,11 +1,19 @@
 val runningGradle5 = gradle.gradleVersion.startsWith("5.")
 
+val pomText = file("../../pom.xml").readText()
+val androidPomText = file("../../android-pom.xml").readText()
 val guavaVersionJre =
-  "<version>(.*)</version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
+  "<version>(.*)</version>".toRegex().find(pomText)?.groups?.get(1)?.value
     ?: error("version not found in pom")
 val checkerVersion =
-  "<checker.version>(.*)</checker.version>".toRegex().find(file("../../pom.xml").readText())?.groups?.get(1)?.value
+  "<checker.version>(.*)</checker.version>".toRegex().find(pomText)?.groups?.get(1)?.value
     ?: error("checker.version not found in pom")
+val errorProneVersionJre =
+  "<errorprone.version>(.*)</errorprone.version>".toRegex().find(pomText)?.groups?.get(1)?.value
+    ?: error("errorprone.version not found in pom")
+val errorProneVersionAndroid =
+  "<errorprone.version>(.*)</errorprone.version>".toRegex().find(androidPomText)?.groups?.get(1)?.value
+    ?: error("errorprone.version not found in android pom")
 
 val expectedReducedRuntimeClasspathAndroidVersion =
   setOf(
@@ -13,7 +21,7 @@ val expectedReducedRuntimeClasspathAndroidVersion =
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
     "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-2.26.1.jar",
+    "error_prone_annotations-$errorProneVersionAndroid.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
 val expectedReducedRuntimeClasspathJreVersion =
@@ -22,13 +30,19 @@ val expectedReducedRuntimeClasspathJreVersion =
     "failureaccess-1.0.2.jar",
     "jsr305-3.0.2.jar",
     "checker-qual-$checkerVersion.jar",
-    "error_prone_annotations-2.26.1.jar",
+    "error_prone_annotations-$errorProneVersionJre.jar",
     "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
   )
 val expectedCompileClasspathAndroidVersion =
   expectedReducedRuntimeClasspathAndroidVersion + setOf("j2objc-annotations-3.0.0.jar")
 val expectedCompileClasspathJreVersion =
   expectedReducedRuntimeClasspathJreVersion + setOf("j2objc-annotations-3.0.0.jar")
+val expectedPomClasspathJreVersion =
+  expectedCompileClasspathJreVersion +
+    setOf(
+      "checker-$checkerVersion.jar",
+      "checker-util-$checkerVersion.jar"
+    )
 
 val extraLegacyDependencies = setOf("google-collections-1.0.jar")
 
@@ -65,7 +79,7 @@ subprojects {
       if (name.startsWith("android")) {
         expectedCompileClasspathAndroidVersion + extraLegacyDependencies
       } else {
-        expectedCompileClasspathJreVersion + extraLegacyDependencies
+        expectedPomClasspathJreVersion + extraLegacyDependencies
       }
     } else {
       // with Gradle Module Metadata

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.49.3-eisop1</checker.version>
+    <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.42.0</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
+    <errorprone.compiler.arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</errorprone.compiler.arg>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -468,7 +469,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+                <arg>${errorprone.compiler.arg}</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.5-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
-    <errorprone.compiler.arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</errorprone.compiler.arg>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -469,7 +468,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>${errorprone.compiler.arg}</arg>
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -144,18 +144,15 @@
               <arg>-XDcompilePolicy=simple</arg>
               <!-- -Xplugin:ErrorProne is set conditionally by a profile. -->
             </compilerArgs>
+	    <!--
             <annotationProcessorPaths>
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
-              </path>
-              <path>
-                <groupId>io.github.eisop</groupId>
-                <artifactId>checker</artifactId>
-                <version>${checker.version}</version>
+                <version>2.23.0</version>
               </path>
             </annotationProcessorPaths>
+	    -->
             <!-- Fork:
 
                  - for JDK8 because we use a javac9 bootclasspath
@@ -468,7 +465,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -144,15 +144,18 @@
               <arg>-XDcompilePolicy=simple</arg>
               <!-- -Xplugin:ErrorProne is set conditionally by a profile. -->
             </compilerArgs>
-	    <!--
             <annotationProcessorPaths>
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.23.0</version>
+                <version>${errorprone.version}</version>
+              </path>
+              <path>
+                <groupId>io.github.eisop</groupId>
+                <artifactId>checker</artifactId>
+                <version>${checker.version}</version>
               </path>
             </annotationProcessorPaths>
-	    -->
             <!-- Fork:
 
                  - for JDK8 because we use a javac9 bootclasspath
@@ -465,7 +468,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.42.0-eisop5</checker.version>
+    <checker.version>3.49.1-eisop1</checker.version>
     <errorprone.version>2.26.1</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.1-eisop1</checker.version>
-    <errorprone.version>2.26.1</errorprone.version>
+    <errorprone.version>2.42.0</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->

--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
+                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,7 @@
                      be passed as part of the same <arg> as -Xplugin:ErrorProne,
                      and I gave up trying to figure out how to do that for test
                      compilation only. -->
-                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>
+<!--                <arg>-Xplugin:ErrorProne -Xep:NullArgumentForNonNullParameter:OFF -Xep:Java8ApiChecker:ERROR</arg>-->
                 <!-- https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md#jdk-16 -->
                 <!-- TODO(cpovirk): Use .mvn/jvm.config instead (per
                      https://errorprone.info/docs/installation#maven) if it can

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <checker.version>3.49.1-eisop1</checker.version>
+    <checker.version>3.49.3-eisop1</checker.version>
     <errorprone.version>2.42.0</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <truth.version>1.4.2</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
     <checker.version>3.49.5-eisop1</checker.version>
-    <errorprone.version>2.42.0</errorprone.version>
+    <errorprone.version>2.26.1</errorprone.version>
     <j2objc.version>3.0.0</j2objc.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->

--- a/util/gradle_integration_tests.sh
+++ b/util/gradle_integration_tests.sh
@@ -20,7 +20,7 @@ set -eu
 GRADLE_TEMP="$(mktemp -d)"
 trap 'rm -rf "${GRADLE_TEMP}"' EXIT
 
-# The Gradle tests need the pom.xml only to read its version numbers.
+# The Gradle tests need the pom.xml only to read its version number.
 # (And the file needs to be two directory levels up from the Gradle build file.)
 # TODO(cpovirk): Find a better way to give them that information.
 cp pom.xml "${GRADLE_TEMP}"

--- a/util/gradle_integration_tests.sh
+++ b/util/gradle_integration_tests.sh
@@ -24,6 +24,7 @@ trap 'rm -rf "${GRADLE_TEMP}"' EXIT
 # (And the file needs to be two directory levels up from the Gradle build file.)
 # TODO(cpovirk): Find a better way to give them that information.
 cp pom.xml "${GRADLE_TEMP}"
+cp android/pom.xml "${GRADLE_TEMP}/android-pom.xml"
 
 for version in 5.6.4 7.0.2; do
   # Enter a subshell so that we return to the current directory afterward.

--- a/util/gradle_integration_tests.sh
+++ b/util/gradle_integration_tests.sh
@@ -20,11 +20,10 @@ set -eu
 GRADLE_TEMP="$(mktemp -d)"
 trap 'rm -rf "${GRADLE_TEMP}"' EXIT
 
-# The Gradle tests need the pom.xml only to read its version number.
+# The Gradle tests need the pom.xml only to read its version numbers.
 # (And the file needs to be two directory levels up from the Gradle build file.)
 # TODO(cpovirk): Find a better way to give them that information.
 cp pom.xml "${GRADLE_TEMP}"
-cp android/pom.xml "${GRADLE_TEMP}/android-pom.xml"
 
 for version in 5.6.4 7.0.2; do
   # Enter a subshell so that we return to the current directory afterward.

--- a/util/gradle_integration_tests.sh
+++ b/util/gradle_integration_tests.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-./mvnw clean install --projects '!guava-testlib,!guava-tests,!guava-bom,!guava-gwt' -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+./mvnw clean install --projects '!guava-testlib,!guava-tests,!guava-bom' -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
 ./mvnw clean install --projects '!guava-testlib,!guava-tests,!guava-bom' -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -f android
 
 # Gradle Wrapper overwrites some files when it runs.


### PR DESCRIPTION
  ## Summary

  This PR updates Guava’s EISOP Checker Framework integration to `3.49.5-eisop1` and keeps the
  published JRE/Android artifact metadata consistent.

  ## Changes

  - Updated Checker Framework version to `3.49.5-eisop1`.
  - Switched Checker Framework dependency coordinates to `io.github.eisop` where needed.
  - Aligned Android artifact versions with the JRE artifact version:
    - `33.1.0.2-jre`
    - `33.1.0.2-android`
  - Updated child POMs and BOMs to use the aligned `33.1.0.2-*` versions.
  - Updated Gradle module metadata for EISOP Checker Framework coordinates.
  - Updated `guava/cfMavenCentral.xml` for `checker-qual 3.49.5-eisop1`.
  - Disabled the Maven Error Prone compiler plugin by keeping both its processor path and
  `-Xplugin:ErrorProne` arg commented out. They were commented out in pom.xml and android/pom.xml.
  - Updated Gradle integration test classpath expectations for the new Checker Framework jars
  and Gradle 5 POM-only resolution.